### PR TITLE
remove GCT duplicates when using Ideal regionizer

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -1006,15 +1006,23 @@ void L1TCorrelatorLayer1Producer::addHGCalHadCalo(const l1t::HGCalMulticluster &
 void L1TCorrelatorLayer1Producer::addGCTEmCaloRaw(const l1tp2::GCTEmDigiClusterLink &link,
                                                   unsigned int linkidx,
                                                   unsigned int entidx) {
-  event_.raw.gctEm[calomapping[linkidx]].obj.push_back(link[entidx].data());
-  addDecodedGCTEmCalo(event_.decoded.emcalo[calomapping[linkidx]], link[entidx]);
+  // in the "Ideal" regionizer, ignore the second set that is sent; only use the first
+  auto caloIdx = calomapping[linkidx];
+  if (caloIdx < event_.raw.gctEm.size()) {
+    event_.raw.gctEm[caloIdx].obj.push_back(link[entidx].data());
+    addDecodedGCTEmCalo(event_.decoded.emcalo[caloIdx], link[entidx]);
+  }
 }
 
 void L1TCorrelatorLayer1Producer::addGCTHadCaloRaw(const l1tp2::GCTHadDigiClusterLink &link,
                                                    unsigned int linkidx,
                                                    unsigned int entidx) {
-  event_.raw.gctHad[calomapping[linkidx]].obj.push_back(link[entidx].data());
-  addDecodedGCTHadCalo(event_.decoded.hadcalo[calomapping[linkidx]], link[entidx]);
+  // in the "Ideal" regionizer, ignore the second set that is sent; only use the first
+  auto caloIdx = calomapping[linkidx];
+  if (caloIdx < event_.raw.gctHad.size()) {
+    event_.raw.gctHad[caloIdx].obj.push_back(link[entidx].data());
+    addDecodedGCTHadCalo(event_.decoded.hadcalo[caloIdx], link[entidx]);
+  }
 }
 
 void L1TCorrelatorLayer1Producer::addDecodedTrack(l1ct::DetectorSector<l1ct::TkObjEmu> &sec, const l1t::PFTrack &t) {

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_cff.py
@@ -106,16 +106,11 @@ l1tLayer1Barrel = cms.EDProducer("L1TCorrelatorLayer1Producer",
     tkEgSorterParameters = tkEgSorterParameters.clone(
         nObjToSort = 10
     ),
-    caloSectors = cms.VPSet(
+    caloSectors = cms.VPSet(   # for Ideal regionizer only--don't include the duplicates
         cms.PSet(
             etaBoundaries = cms.vdouble(-1.5, 0, 1.5),
             phiSlices     = cms.uint32(3),
             phiZero       = cms.double(math.pi/18)
-        ),
-        cms.PSet(
-            etaBoundaries = cms.vdouble(-1.5, 0, 1.5),
-            phiSlices     = cms.uint32(3),
-            phiZero       = cms.double(math.pi*7/18)
         )
     ),
     regions = cms.VPSet(

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -112,6 +112,21 @@ process.l1tLayer1BarrelTDR.puAlgoParameters.finalSortAlgo = "BitonicVHDL"
 process.l1tLayer1BarrelTDR.tkEgAlgoParameters.nTRACK_EGIN = 22
 process.l1tLayer1BarrelTDR.tkEgAlgoParameters.nEMCALO_EGIN = 12
 
+process.l1tLayer1BarrelTDR.hadClusters = cms.InputTag('l1tPhase2GCTBarrelToCorrelatorLayer1Emulator', 'GCTHadDigiClusters')
+process.l1tLayer1BarrelTDR.gctHadInputConversionAlgo = cms.string("Emulator")
+
+process.l1tLayer1BarrelTDR.caloSectors = cms.VPSet(
+        cms.PSet(
+            etaBoundaries = cms.vdouble(-1.5, 0, 1.5),
+            phiSlices     = cms.uint32(3),
+            phiZero       = cms.double(math.pi/18)
+        ),
+        cms.PSet(
+            etaBoundaries = cms.vdouble(-1.5, 0, 1.5),
+            phiSlices     = cms.uint32(3),
+            phiZero       = cms.double(math.pi*7/18)
+        )
+    )
 
 process.l1tLayer1BarrelSerenity = process.l1tLayer1Barrel.clone()
 process.l1tLayer1BarrelSerenity.regionizerAlgo = "MultififoBarrel"


### PR DESCRIPTION
Can you see if this removes the GCT duplicates? I think it only takes one of the two sets of duplicates when you are using the Ideal regionizer. In `make_l1ct_binaryFiles_cfg.py` we define both sets of caloSectors for both the TDR and multififo regionizers, so they have to deal with duplicates internally.