### PR TITLE
Address review comments for L1 MET

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFJUMPEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFJUMPEmulator.h
@@ -10,7 +10,7 @@
 
 #include "FWCore/Utilities/interface/FileInPath.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "nlohmann/json.hpp"
+#include <nlohmann/json.hpp>
 
 #include <vector>
 #include <numeric>

--- a/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFMetEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFMetEmulator.h
@@ -7,7 +7,7 @@
 
 #include "L1Trigger/Phase2L1ParticleFlow/interface/dbgPrintf.h"
 
-#include "nlohmann/json.hpp"
+#include <nlohmann/json.hpp>
 
 #ifdef CMSSW_GIT_HASH
 #include "FWCore/Utilities/interface/FileInPath.h"
@@ -159,14 +159,17 @@ namespace L1METEmu {
     // convert x, y coordinate to pt, phi coordinate using math library
     hls_met.clear();
 
-#ifdef CMSSW_GIT_HASH
-    hls_met.hwPt = hypot(met_xy.hwPx.to_float(), met_xy.hwPy.to_float());
-    hls_met.hwPhi = phi_t(ap_fixed<26, 11>(atan2(met_xy.hwPy.to_float(), met_xy.hwPx.to_float())) *
-                          ap_fixed<26, 11>(229.29936));  // Scale for L1 phi value (720 / M_PI)
-#else
-    hls_met.hwPt = hls::hypot(met_xy.hwPx, met_xy.hwPy);
-    hls_met.hwPhi = phi_t(ap_fixed<26, 11>(hls::atan2(met_xy.hwPy, met_xy.hwPx)) * ap_fixed<26, 11>(229.29936));
-#endif
+    // Convert (px,py) -> (pt,phi)
+    // phi_L1 = phi_rad * (720 / pi), so that phi in [-pi, pi) maps to approximately [-720, 720).
+    // 229.29936 is the numerical value of (720 / M_PI).
+    #ifdef CMSSW_GIT_HASH
+        hls_met.hwPt = hypot(met_xy.hwPx.to_float(), met_xy.hwPy.to_float());
+        hls_met.hwPhi = phi_t(ap_fixed<26, 11>(atan2(met_xy.hwPy.to_float(), met_xy.hwPx.to_float())) *
+                              ap_fixed<26, 11>(229.29936));
+    #else
+        hls_met.hwPt = hls::hypot(met_xy.hwPx, met_xy.hwPy);
+        hls_met.hwPhi = phi_t(ap_fixed<26, 11>(hls::atan2(met_xy.hwPy, met_xy.hwPx)) * ap_fixed<26, 11>(229.29936));
+    #endif
   }
 
   inline void met_format(const l1ct::Sum d, ap_uint<l1gt::Sum::BITWIDTH>& q) {

--- a/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFMetEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFMetEmulator.h
@@ -159,16 +159,16 @@ namespace L1METEmu {
     // convert x, y coordinate to pt, phi coordinate using math library
     hls_met.clear();
 
-    // Convert (px,py) -> (pt,phi)
-    // phi_L1 = phi_rad * (720 / pi), so that phi in [-pi, pi) maps to approximately [-720, 720).
-    // 229.183118 is the numerical value of (720 / M_PI).
+    // Convert (px, py) -> (pt, phi)
+    // INTPHI_PI = 720, so phi_L1 = phi_rad * (INTPHI_PI / M_PI). This maps phi in [-pi, pi] to [-720, 720].
+    static const float phi_scale = l1ct::Scales::INTPHI_PI / M_PI;
 #ifdef CMSSW_GIT_HASH
     hls_met.hwPt = hypot(met_xy.hwPx.to_float(), met_xy.hwPy.to_float());
     hls_met.hwPhi = phi_t(ap_fixed<26, 11>(atan2(met_xy.hwPy.to_float(), met_xy.hwPx.to_float())) *
-                          ap_fixed<26, 11>(229.183118));
+                          ap_fixed<26, 11>(phi_scale));
 #else
     hls_met.hwPt = hls::hypot(met_xy.hwPx, met_xy.hwPy);
-    hls_met.hwPhi = phi_t(ap_fixed<26, 11>(hls::atan2(met_xy.hwPy, met_xy.hwPx)) * ap_fixed<26, 11>(229.183118));
+    hls_met.hwPhi = phi_t(ap_fixed<26, 11>(hls::atan2(met_xy.hwPy, met_xy.hwPx)) * ap_fixed<26, 11>(phi_scale));
 #endif
   }
 

--- a/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFMetEmulator.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/jetmet/L1PFMetEmulator.h
@@ -161,15 +161,15 @@ namespace L1METEmu {
 
     // Convert (px,py) -> (pt,phi)
     // phi_L1 = phi_rad * (720 / pi), so that phi in [-pi, pi) maps to approximately [-720, 720).
-    // 229.29936 is the numerical value of (720 / M_PI).
-    #ifdef CMSSW_GIT_HASH
-        hls_met.hwPt = hypot(met_xy.hwPx.to_float(), met_xy.hwPy.to_float());
-        hls_met.hwPhi = phi_t(ap_fixed<26, 11>(atan2(met_xy.hwPy.to_float(), met_xy.hwPx.to_float())) *
-                              ap_fixed<26, 11>(229.29936));
-    #else
-        hls_met.hwPt = hls::hypot(met_xy.hwPx, met_xy.hwPy);
-        hls_met.hwPhi = phi_t(ap_fixed<26, 11>(hls::atan2(met_xy.hwPy, met_xy.hwPx)) * ap_fixed<26, 11>(229.29936));
-    #endif
+    // 229.183118 is the numerical value of (720 / M_PI).
+#ifdef CMSSW_GIT_HASH
+    hls_met.hwPt = hypot(met_xy.hwPx.to_float(), met_xy.hwPy.to_float());
+    hls_met.hwPhi = phi_t(ap_fixed<26, 11>(atan2(met_xy.hwPy.to_float(), met_xy.hwPx.to_float())) *
+                          ap_fixed<26, 11>(229.183118));
+#else
+    hls_met.hwPt = hls::hypot(met_xy.hwPx, met_xy.hwPy);
+    hls_met.hwPhi = phi_t(ap_fixed<26, 11>(hls::atan2(met_xy.hwPy, met_xy.hwPx)) * ap_fixed<26, 11>(229.183118));
+#endif
   }
 
   inline void met_format(const l1ct::Sum d, ap_uint<l1gt::Sum::BITWIDTH>& q) {


### PR DESCRIPTION
This PR addresses the review comments on the L1 MET changes.

- Use the proper nlohmann/json header include (via cms-dist) as suggested in the review.
- Add comments explaining the phi scaling constant and the fixed-point casts (chosen to avoid division in HLS and to keep resource/latency under control).