### PR TITLE
add missing algorithm include

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/egamma/pftkegsorter_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/egamma/pftkegsorter_ref.h
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include <vector>
+#include <algorithm>
 
 #include "DataFormats/L1TParticleFlow/interface/layer1_emulator.h"
 #include "L1Trigger/Phase2L1ParticleFlow/interface/dbgPrintf.h"


### PR DESCRIPTION
The `#include <algorithm>` is needed for the `std::reverse` and `std::stable_sort` calls on lines 72 and 73.